### PR TITLE
Issue 23

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tableHTML
 Type: Package
 Title: A Tool to Create HTML Tables
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Theo", "Boutaris", email = "teoboot2007@hotmail.com", role = c("aut", "cre", "cph")),
     person("Clemens", "Zauchner", email = "cst.zauchner@gmail.com", role = "aut"))

--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -345,9 +345,8 @@ add_css_conditional_column <- function(tableHTML,
       
     } else {
       
-      tableHTML <- replace_style(tableHTML, split = paste0('id="tableHTML_column_', i, '"'),
-                                 style[[attributes$headers[i]]],
-                                 condition[[attributes$headers[i]]])
+      tableHTML <- replace_style(tableHTML, split = paste0("id=\"tableHTML_column_", 
+                                                           i, "\""), style[[i]], condition[[i]])
       attributes(tableHTML) <- attributes
     }
   }

--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -309,6 +309,8 @@ add_css_conditional_column <- function(tableHTML,
                                            conditional = conditional,
                                            same_scale = same_scale,
                                            comparison_value = comparison_value)
+    names(condition) <- all_names
+    
   }
   
   if (!is.null(colour_rank_theme_colours)) {

--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -264,8 +264,7 @@ add_css_conditional_column <- function(tableHTML,
     indices <- sort(indices)
   }
   
-  all_names <- c(c('row_groups', 'rownames'),
-                 attributes$headers)[which(c(-1, 0, 1:attributes$ncols) %in% indices)]
+  all_names <- as.character(indices)
   
   #create style for conditionals
   style <- switch(conditional,
@@ -321,7 +320,11 @@ add_css_conditional_column <- function(tableHTML,
   }
  
   if (is.null(style)) {
-    style <- lapply(all_names, function(name) {
+    
+    col_names <- c(c('row_groups', 'rownames'),
+                 attributes$headers)[which(c(-1, 0, 1:attributes$ncols) %in% indices)]
+    
+    style <- lapply(col_names, function(name) {
       make_style_from_css("column")(colour_rank_css, name)
     })
     names(style) <- all_names
@@ -333,20 +336,23 @@ add_css_conditional_column <- function(tableHTML,
     
     if (isTRUE(all.equal(i, 0))) {
       
-      tableHTML <- replace_style(tableHTML, split = 'id="tableHTML_rownames"', style[["rownames"]],
-                                 condition[["rownames"]])
+      tableHTML <- replace_style(tableHTML, split = 'id="tableHTML_rownames"', 
+                                 style[[as.character(i)]],
+                                 condition[[as.character(i)]])
       attributes(tableHTML) <- attributes
 
     } else if (isTRUE(all.equal(i, -1))) {
 
-      tableHTML <- replace_style(tableHTML, split = 'id="tableHTML_row_groups"', style[["row_groups"]],
-                                 condition[["row_groups"]])
+      tableHTML <- replace_style(tableHTML, split = 'id="tableHTML_row_groups"', 
+                                 style[[as.character(i)]],
+                                 condition[[as.character(i)]])
       attributes(tableHTML) <- attributes
       
     } else {
       
-      tableHTML <- replace_style(tableHTML, split = paste0("id=\"tableHTML_column_", 
-                                                           i, "\""), style[[i]], condition[[i]])
+      tableHTML <- replace_style(tableHTML, split = paste0('id="tableHTML_column_', i, '"'),
+                                 style[[as.character(i)]],
+                                 condition[[as.character(i)]])
       attributes(tableHTML) <- attributes
     }
   }


### PR DESCRIPTION
This fixes the [issue 23](https://github.com/LyzandeR/tableHTML/issues/23).

Instead of subsetting the `style` and `condition` lists with the names of the headers, now the indices are used, but as a character vector. 

This should only be a temporary fix until the original data is added to the attributes!!