### PR TITLE
Add selector to tableHTML_to_image arguments

### DIFF
--- a/R/tableHTML2image.R
+++ b/R/tableHTML2image.R
@@ -27,6 +27,8 @@
 #'
 #' @param ... Parameters passed on to webshot. Check \code{\link[webshot]{webshot}}.
 #'
+#' @inheritParams webshot::webshot
+#'
 #' @return An image of the tableHTML.
 #'
 #' @examples
@@ -41,6 +43,7 @@ tableHTML_to_image <- function(tableHTML,
                                file = NULL,
                                type = c('png', 'jpeg'),
                                add = FALSE,
+                               selector = 'table',
                                ...) {
 
  #check type
@@ -73,7 +76,7 @@ tableHTML_to_image <- function(tableHTML,
  #webshot the image into the temp file
  webshot::webshot(temp_file,
                   file = image,
-                  selector = 'table',
+                  selector = selector,
                   ...)
 
  #read the image to display to markdown

--- a/man/tableHTML_to_image.Rd
+++ b/man/tableHTML_to_image.Rd
@@ -5,7 +5,7 @@
 \title{Convert a tableHTML into an image}
 \usage{
 tableHTML_to_image(tableHTML, file = NULL, type = c("png", "jpeg"),
-  add = FALSE, ...)
+  add = FALSE, selector = "table", ...)
 }
 \arguments{
 \item{tableHTML}{A tableHTML object created by the tableHTML function.}
@@ -17,6 +17,14 @@ displayed on screen.}
 
 \item{add}{Logical. If TRUE, the plot will be added to the existing plot.
 If FALSE, the current device will be shut down.}
+
+\item{selector}{One or more CSS selectors specifying a DOM element to set the
+clipping rectangle to. The screenshot will contain these DOM elements. For
+a given selector, if it has more than one match, only the first one will be
+used. This option is not compatible with \code{cliprect}. When taking
+screenshots of multiple URLs, this parameter can also be a list with same
+length as \code{url} with each element of the list containing a vector of
+CSS selectors to use for the corresponding URL.}
 
 \item{...}{Parameters passed on to webshot. Check \code{\link[webshot]{webshot}}.}
 }


### PR DESCRIPTION
The added selector argument with 'table' as default is needed if you add additional HTML to a table, e.g. for the hex logo.

The documentation of the argument is inherited from webshot::webshot.