### PR TITLE
Colour scaling with uneven intervals

### DIFF
--- a/R/make_css_conditional_format.R
+++ b/R/make_css_conditional_format.R
@@ -63,19 +63,30 @@ make_css_colour_rank_theme <- function(column_data,
 
     css_colours <- character(length(cd))
 
-    colors <- if (decreasing) rev(colors) else colors
+    if (is.numeric(cols_context(cd))) {
+     colors <- if (decreasing) rev(colors) else colors
 
-    colour_palette <- colorRampPalette(colors)
+     colour_palette <- colorRampPalette(colors)
 
-    colsteps <- max(cols_context(cd)) - min(cols_context(cd)) + 1
+     colsteps <- max(cols_context(cd)) - min(cols_context(cd)) + 1
 
-    value <- unique(cols_context(cd))[order(unique(cols_context(cd)),
-                                            decreasing = decreasing)]
+     value <- unique(cols_context(cd))[order(unique(cols_context(cd)),
+                                             decreasing = decreasing)]
 
-    colour <- colour_palette(colsteps)[findInterval(value,
-                                                    seq(min(value),
-                                                        max(value),
-                                                        length.out = colsteps))]
+     colour <- colour_palette(colsteps)[findInterval(value,
+                                                     seq(min(value),
+                                                         max(value),
+                                                         length.out = colsteps))]
+    } else {
+     value <- unique(cols_context(cd))[order(unique(cols_context(cd)),
+                                             decreasing = decreasing)]
+
+     colour_palette <- colorRampPalette(colors)
+
+     colour <- colour_palette(length(unique(cols_context(cd))))
+    }
+
+
 
     col_df <- data.frame(value = value,
                          colour = colour,

--- a/R/make_css_conditional_format.R
+++ b/R/make_css_conditional_format.R
@@ -4,91 +4,102 @@ NULL
 #' Get css properties for custom colour rank theme
 #'
 #' \code{make_css_colour_rank_theme} will create a list of css properties needed for custom conditional formatting.
-#' 
+#'
 #' \code{make_css_colour_rank_theme} will add conditional css to a tableHTML's columns. \code{add_conditional_css_column} will only
 #'   add css to the columns without the headers or second headers (i.e. it only affects the td tag
 #'   internally and not the th tag). If you want to add css to the headers or second headers please
-#'   use \code{add_css_header} or \code{add_css_second_header}. 
+#'   use \code{add_css_header} or \code{add_css_second_header}.
 #'
 #' @param column_data A named list of vectors of values that are in a tableHTML column which
-#'  should be mapped to a colour palette. 
+#'  should be mapped to a colour palette.
 #'
-#' @param css_property Character. An optional character specifying the css attribute 
+#' @param css_property Character. An optional character specifying the css attribute
 #' that should be used. Default is \code{'backgroud-color'}
-#'   
+#'
 #' @inheritParams grDevices::colorRampPalette
 #' @inheritParams base::order
 #' @inheritParams add_css_conditional_column
 #'
-#' @return A list of css properties 
-#'         
+#' @return A list of css properties
+#'
 #' @examples
-#' 
+#'
 #' tableHTML <- tableHTML(mtcars)
-#' 
+#'
 #' css <- make_css_colour_rank_theme(list(mpg = mtcars$mpg),
 #'                                  c("orange", "yellow","springgreen","royalblue"))
-#' 
+#'
 #' tableHTML %>% add_css_conditional_column(conditional = "colour_rank",
-#'                                         colour_rank_theme = "Custom", 
+#'                                         colour_rank_theme = "Custom",
 #'                                         colour_rank_css = css, column = 1)
-#' 
+#'
 #' @export
 
 make_css_colour_rank_theme <- function(column_data,
                                        colors,
                                        css_property = "background-color",
-                                       decreasing = FALSE, 
+                                       decreasing = FALSE,
                                        same_scale = TRUE) {
-  
+
   #checks
   if (class(column_data) != 'list' | is.null(names(column_data))) {
     stop('column_data must be a named list')
   }
-  
+
   check <- tryCatch(col2rgb(colors),
     error = function(e) {
       stop('colors argument not valid. see ?col2rgb for more details')
     }
   )
-  
+
   col_names <- names(column_data)
 
   cols_context <- switch(ifelse(same_scale, "TRUE", "FALSE"),
                          "TRUE" = function(x) { return(unname(unlist(column_data))) },
                          "FALSE" = function(y) { return(y) }
   )
-  
+
   css <- lapply(column_data, function(cd) {
-    
+
     css_colours <- character(length(cd))
+
+    colors <- if (decreasing) rev(colors) else colors
+
     colour_palette <- colorRampPalette(colors)
-    
-    col_df <- data.frame(value = unique(cols_context(cd))[order(unique(cols_context(cd)), 
-                                                                decreasing = decreasing)],
-                         colour = colour_palette(length(unique(cols_context(cd)))),
+
+    colsteps <- max(cols_context(cd)) - min(cols_context(cd)) + 1
+
+    value <- unique(cols_context(cd))[order(unique(cols_context(cd)),
+                                            decreasing = decreasing)]
+
+    colour <- colour_palette(colsteps)[findInterval(value,
+                                                    seq(min(value),
+                                                        max(value),
+                                                        length.out = colsteps))]
+
+    col_df <- data.frame(value = value,
+                         colour = colour,
                          stringsAsFactors = FALSE)
-    
-    css_colours[1:length(cd)] <- 
+
+    css_colours[1:length(cd)] <-
       vapply(1:length(cd), function(i) {
-        
+
         col_df$colour[which(col_df$value %in%  cd[i])]
-        
+
       }, FUN.VALUE = character(1))
-    
+
     list(c(css_property), list(c(css_colours)))
-    
-    
+
+
   })
 
   names(css) <- col_names
-  
+
   return(css)
 }
-  
 
-  
 
-  
 
-  
+
+
+

--- a/tests/testthat/test_add_css_conditional_column.R
+++ b/tests/testthat/test_add_css_conditional_column.R
@@ -1,106 +1,106 @@
 context("add_css_conditional_column testing")
 
 test_that("Function fails for wrong inputs", {
- 
+
   # no tableHTML
   expect_error(add_css_conditional_column(mtcars, 1),
                'tableHTML needs to be')
-  
+
   # no columns specified
   expect_error(tableHTML(mtcars) %>% add_css_conditional_column(conditional = "==", value = 1,
-                                                                css = list('background-color', 'lightgray')), 
+                                                                css = list('background-color', 'lightgray')),
                'argument "columns" is missing, with no default')
-  
+
   # wrong conditional argument
   expect_error(tableHTML(mtcars) %>% add_css_conditional_column(columns = 1,
-                                                                conditional = "blubb"), 
+                                                                conditional = "blubb"),
                "arg' should be one of ")
-  
-  # no css provided
-  expect_error(tableHTML(mtcars) %>% add_css_conditional_column(conditional = "==", value = 1, column = 1), 
-               'css needs to be provided')
-  
 
-  
+  # no css provided
+  expect_error(tableHTML(mtcars) %>% add_css_conditional_column(conditional = "==", value = 1, column = 1),
+               'css needs to be provided')
+
+
+
   # typeof columns numeric and character
-  expect_error(tableHTML(mtcars) %>% 
+  expect_error(tableHTML(mtcars) %>%
                  add_css_conditional_column(conditional = "==", value = 1,
                                             columns = c("rownames", 1),
-                                            css = list('background-color', 'lightgray')), 
+                                            css = list('background-color', 'lightgray')),
                'columns must either be numeric or text')
-  
+
   # no rownames in tableHTML, but css to be applied
   expect_error(tableHTML(mtcars, rownames = FALSE) %>%
                  add_css_conditional_column(conditional = "==", value = 1,
                                             columns = c("rownames"),
                                             css = list('background-color', 'lightgray')),
                'tableHTML does not have rownames')
-  
+
   # no rowgroups in tableHTML, but css to be applied
   expect_error(tableHTML(mtcars, rownames = FALSE) %>%
                  add_css_conditional_column(conditional = "==", value = 1,
                                             columns = c("row_groups"),
                                             css = list('background-color', 'lightgray')),
                'tableHTML does not have row_groups')
-  
+
   #begin and end values missing
-  expect_error(tableHTML(mtcars) %>% 
+  expect_error(tableHTML(mtcars) %>%
                  add_css_conditional_column(conditional = "between",
                                             columns = c(1),
-                                            css = list('background-color', 'lightgray')), 
+                                            css = list('background-color', 'lightgray')),
                'begin and end values for between need to be provided')
-  
+
   # length of between not 2
-  expect_error(tableHTML(mtcars) %>% 
+  expect_error(tableHTML(mtcars) %>%
                  add_css_conditional_column(conditional = "between", between = 1,
                                             columns = c(1),
-                                            css = list('background-color', 'lightgray')), 
+                                            css = list('background-color', 'lightgray')),
                'between needs to be a vector')
-  
+
   # between not a numeric vector
-  expect_error(tableHTML(mtcars) %>% 
+  expect_error(tableHTML(mtcars) %>%
                  add_css_conditional_column(conditional = "between", between = list(1, 2),
                                             columns = c(1),
-                                            css = list('background-color', 'lightgray')), 
+                                            css = list('background-color', 'lightgray')),
                'between needs to be a vector')
-  
+
   # begin ! <= end
-  expect_error(tableHTML(mtcars) %>% 
+  expect_error(tableHTML(mtcars) %>%
                  add_css_conditional_column(conditional = "between", between = c(2, 1),
                                             columns = c(1),
-                                            css = list('background-color', 'lightgray')), 
+                                            css = list('background-color', 'lightgray')),
                'begin must be smaller than end in between')
-                                            
+
   # top_n warning
-  expect_warning(tableHTML(mtcars) %>% 
+  expect_warning(tableHTML(mtcars) %>%
                    add_css_conditional_column(conditional = "top_n",
                                               columns = c(1),
-                                              css = list('background-color', 'lightgray')), 
+                                              css = list('background-color', 'lightgray')),
                  'n not provided')
-  
+
   # bottom_n warning
-  expect_warning(tableHTML(mtcars) %>% 
+  expect_warning(tableHTML(mtcars) %>%
                    add_css_conditional_column(conditional = "bottom_n",
                                               columns = c(1),
-                                              css = list('background-color', 'lightgray')), 
+                                              css = list('background-color', 'lightgray')),
                  'n not provided')
-  
-  
-  
+
+
+
 })
 
 test_that("equations and inequations work", {
-  
+
   #test that css is applied to column 1, row 4 + 32
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
         add_css_conditional_column(conditional = "==", value = 21.4, css = list('background-color', "green"), columns = c("mpg"))
-      
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:green;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
@@ -112,19 +112,19 @@ test_that("equations and inequations work", {
     {
       tableHTML <- tableHTML(mtcars) %>%
         add_css_conditional_column(conditional = "!=", value = 21.4, css = list('background-color', "green"), columns = c("mpg"))
-      
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:green;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
-    expected = c(2, 14, 26, 50, 62, 74, 86, 98, 110, 122, 134, 146, 158, 170, 182, 194, 
+    expected = c(2, 14, 26, 50, 62, 74, 86, 98, 110, 122, 134, 146, 158, 170, 182, 194,
                  206, 218, 230, 242, 254, 266, 278, 290, 302, 314, 326, 338, 350, 362)
   )
-  
+
   #test inequations
   expect_equal(
     {
@@ -133,9 +133,9 @@ test_that("equations and inequations work", {
         add_css_conditional_column(conditional = "<=", value = 75.7, css = list('background-color', "blue"), columns = c("disp")) %>%
         add_css_conditional_column(conditional = ">", value = 4, css = list('background-color', "red"), columns = c("gear")) %>%
         add_css_conditional_column(conditional = ">=", value = 6, css = list('background-color', "orange"), columns = c("carb"))
-      
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
       c(
         which(vapply(seq_along(starts), function(i) {
@@ -154,15 +154,15 @@ test_that("equations and inequations work", {
     },
     expected = c(74, 170, 182, 278, 220, 232, 323, 335, 347, 359, 371, 360, 372)
   )
-  
+
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
         add_css_conditional_column(conditional = ">", value = 4.43, css = list('background-color', "orange"), columns = c("drat", "wt"))
-      
-      
+
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
@@ -170,172 +170,172 @@ test_that("equations and inequations work", {
     },
     expected = c(175, 187, 199, 222)
   )
-  
+
 })
 
 test_that("min max work", {
-  
+
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "min", css = list('background-color', "orange"), columns = c("qsec")) 
-      
+        add_css_conditional_column(conditional = "min", css = list('background-color', "orange"), columns = c("qsec"))
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = 344
   )
-  
+
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "max", css = list('background-color', "orange"), columns = c("qsec")) 
-      
+        add_css_conditional_column(conditional = "max", css = list('background-color', "orange"), columns = c("qsec"))
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = 104
   )
-  
+
   #test that only 1 highlighted
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "min",css = list('background-color', "orange"), 
-                                   columns = c("gear", "carb"), same_scale = TRUE) 
-      
+        add_css_conditional_column(conditional = "min",css = list('background-color', "orange"),
+                                   columns = c("gear", "carb"), same_scale = TRUE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = c(36, 48, 72, 216, 240, 252, 312)
   )
-  
+
   #test 1 in carb and 3 in gear highlighted
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "min",css = list('background-color', "orange"), 
-                                   columns = c("gear", "carb"), same_scale = FALSE) 
-      
+        add_css_conditional_column(conditional = "min",css = list('background-color', "orange"),
+                                   columns = c("gear", "carb"), same_scale = FALSE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = c(36, 47, 48, 59, 71, 72, 83, 143, 155, 167, 179, 191, 203, 216, 240, 251, 252, 263, 275, 287, 299, 312)
   )
-  
+
 })
 
 test_that("top_n and bottom_n work", {
-  
+
   #top 5 in drat, top in wt
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "top_n", n = 5, css = list('background-color', "orange"), 
-                                   columns = c("drat", "wt"), same_scale = FALSE) 
-      
+        add_css_conditional_column(conditional = "top_n", n = 5, css = list('background-color', "orange"),
+                                   columns = c("drat", "wt"), same_scale = FALSE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = c(139, 175, 187, 199, 222, 234, 295, 318, 342, 378)
   )
-  
+
   #top 5 in drat AND wt
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "top_n", n = 5, css = list('background-color', "orange"), 
-                                   columns = c("drat", "wt"), same_scale = TRUE) 
-      
+        add_css_conditional_column(conditional = "top_n", n = 5, css = list('background-color', "orange"),
+                                   columns = c("drat", "wt"), same_scale = TRUE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = c(175, 187, 199, 222, 318)
   )
-  
+
   #bottom_1 == min
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "bottom_n", n = 1, css = list('background-color', "orange"), 
-                                   columns = c("drat", "wt"), same_scale = TRUE) 
-      
+        add_css_conditional_column(conditional = "bottom_n", n = 1, css = list('background-color', "orange"),
+                                   columns = c("drat", "wt"), same_scale = TRUE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "min", css = list('background-color', "orange"), 
-                                   columns = c("drat", "wt"), same_scale = TRUE) 
-      
+        add_css_conditional_column(conditional = "min", css = list('background-color', "orange"),
+                                   columns = c("drat", "wt"), same_scale = TRUE)
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     }
   )
-  
+
 })
 
 test_that("between works", {
-  
+
   expect_equal(
     {
       tableHTML <- tableHTML(mtcars) %>%
-        add_css_conditional_column(conditional = "between", between = c(3.5, 3.7), css = list('background-color', "orange"), 
-                                   columns = c("drat")) 
-      
+        add_css_conditional_column(conditional = "between", between = c(3.5, 3.7), css = list('background-color', "orange"),
+                                   columns = c("drat"))
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      
+
       which(vapply(seq_along(starts), function(i) {
         grepl('style="background-color:orange;"', substr(tableHTML, starts[i], ends[i] + 4))
       }, FUN.VALUE = logical(1)))
     },
     expected = c(90, 246, 354, 366)
   )
-  
-  
-  
+
+
+
 })
 
 test_that("colour rank works", {
@@ -344,24 +344,24 @@ test_that("colour rank works", {
     {
       tableHTML <- tableHTML(mtcars) %>%
         add_css_conditional_column(conditional = "colour_rank", colour_rank_theme = "RAG",
-                                   columns = c("carb")) 
-      
+                                   columns = c("carb"))
+
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      colours <- 
+      colours <-
         vapply(seq_along(starts), function(i) {
           td <- substr(tableHTML, starts[i], ends[i] + 4)
           ifelse(grepl('style="', td), substr(td, gregexpr("#", td)[[1]], gregexpr("#", td)[[1]] + 6), NA_character_)
         }, FUN.VALUE = character(1))
       colours <- colours[!is.na(colours)]
     },
-    expected = c('#F6D38A', '#F6D38A', '#86C183', '#86C183', '#AED088', '#86C183', '#F6D38A', '#AED088',
-                 '#AED088', '#F6D38A', '#F6D38A', '#E1E28E', '#E1E28E', '#E1E28E', '#F6D38A', '#F6D38A', 
-                 '#F6D38A', '#86C183', '#AED088', '#86C183', '#86C183', '#AED088', '#AED088', '#F6D38A',
-                 '#AED088', '#86C183', '#AED088', '#AED088', '#F6D38A', '#F0A07B', '#F8696B', '#AED088')
+    expected = c('#E8E58F', '#E8E58F', '#86C183', '#86C183', '#A3CB87', '#86C183', '#E8E58F', '#A3CB87',
+                 '#A3CB87', '#E8E58F', '#E8E58F', '#C2D78B', '#C2D78B', '#C2D78B', '#E8E58F', '#E8E58F',
+                 '#E8E58F', '#86C183', '#A3CB87', '#86C183', '#86C183', '#A3CB87', '#A3CB87', '#E8E58F',
+                 '#A3CB87', '#86C183', '#A3CB87', '#A3CB87', '#E8E58F', '#F0B681', '#F8696B', '#A3CB87')
   )
-  
+
   # check colours on same scale
   expect_equal(
     {
@@ -369,21 +369,21 @@ test_that("colour rank works", {
         add_css_conditional_column(conditional = "colour_rank", colour_rank_theme = "RAG",
                                    columns = c("a", "b"), same_scale = TRUE)
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      colours <- 
+      colours <-
         vapply(seq_along(starts), function(i) {
           td <- substr(tableHTML, starts[i], ends[i] + 4)
           ifelse(grepl('style="', td), substr(td, gregexpr("#", td)[[1]], gregexpr("#", td)[[1]] + 6), NA_character_)
         }, FUN.VALUE = character(1))
-      
+
     },
-    expected = c('#86C183', '#86C183', '#9CC986', '#9CC986', '#B3D189', 
+    expected = c('#86C183', '#86C183', '#9CC986', '#9CC986', '#B3D189',
                  '#B3D189', '#CFDC8C', '#CFDC8C', '#EDE690', '#EDE690',
-                 '#F9DE8D', '#86C183', '#F3C285', '#9CC986', '#F0A67C', 
+                 '#F9DE8D', '#86C183', '#F3C285', '#9CC986', '#F0A67C',
                  '#B3D189', '#F38773', '#CFDC8C', '#F8696B', '#EDE690')
   )
-  
+
   #check independent scales
   expect_equal(
     {
@@ -391,19 +391,19 @@ test_that("colour rank works", {
         add_css_conditional_column(conditional = "colour_rank", colour_rank_theme = "RAG",
                                    columns = c("a", "b"), same_scale = FALSE)
       starts <- gregexpr("<td", tableHTML)[[1]]
-      
+
       ends <- gregexpr("</td>", tableHTML)[[1]]
-      colours <- 
+      colours <-
         vapply(seq_along(starts), function(i) {
           td <- substr(tableHTML, starts[i], ends[i] + 4)
           ifelse(grepl('style="', td), substr(td, gregexpr("#", td)[[1]], gregexpr("#", td)[[1]] + 6), NA_character_)
         }, FUN.VALUE = character(1))
-      
+
     },
     expected = c('#86C183', '#86C183', '#9CC986', '#B9D48A', '#B3D189',
                  '#FCEC92', '#CFDC8C', '#EFAE7F', '#EDE690', '#F8696B',
                  '#F9DE8D', '#86C183', '#F3C285', '#B9D48A', '#F0A67C',
                  '#FCEC92', '#F38773', '#EFAE7F', '#F8696B', '#F8696B')
   )
-  
+
 })

--- a/tests/testthat/test_make_css_colour_rank_theme.R
+++ b/tests/testthat/test_make_css_colour_rank_theme.R
@@ -4,23 +4,23 @@ test_that("Function fails for wrong inputs", {
   #column_data not a list
   expect_error(make_css_colour_rank_theme(mtcars$mpg, colors = c("#1FFF6F")),
                'column_data must be a named list')
-  
+
   #column_data not a named list
   expect_error(make_css_colour_rank_theme(list(mtcars$mpg), colors = c("#1FFF6F")),
                'column_data must be a named list')
-  
-  # colors argument not valid 
+
+  # colors argument not valid
   expect_error(make_css_colour_rank_theme(list(mpg = mtcars$mpg), colors = c("#FFF6F")),
                'colors argument not valid.')
-  
+
   #all checks ok
   expect_error(make_css_colour_rank_theme(list(mpg = mtcars$mpg), colors = c("#1FFF6F")),
                NA)
-  
+
 })
 
 test_that("Test returned css ", {
-  
+
   #check class
   expect_equal(class(make_css_colour_rank_theme(list(mpg = mtcars$mpg),
                                                 colors = c("#1FFF6F"))),
@@ -29,16 +29,104 @@ test_that("Test returned css ", {
   expect_equal(names(make_css_colour_rank_theme(list(mpg = mtcars$mpg),
                                                 colors = c("#1FFF6F"))),
                "mpg")
-  
+
   #check css property
-  expect_equal(unique(make_css_colour_rank_theme(list(mpg = mtcars$mpg), 
+  expect_equal(unique(make_css_colour_rank_theme(list(mpg = mtcars$mpg),
                                                  colors = c("#1FFF6F"))$mpg[[1]][[1]]),
                "background-color")
-  
+
   #check css property values
-  expect_equal(unique(make_css_colour_rank_theme(list(mpg = mtcars$mpg), 
+  expect_equal(unique(make_css_colour_rank_theme(list(mpg = mtcars$mpg),
                                                  colors = c("#1FFF6F"))$mpg[[2]][[1]]),
                "#1FFF6F")
-  
+
 })
+
+test_that("colour to value mapping is correct", {
+ expect_equal(
+  {
+   # column a, decreasing TRUE
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, 10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = TRUE,
+                                     same_scale = FALSE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#F8696B", "#F48773", "#F0A67C", "#F3C285", "#86C183",
+               "#F8696B", "#F48773", "#F0A67C", "#F3C285", "#86C183")
+  )
+ expect_equal(
+  {
+   # column b, decreasing TRUE
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, 10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = TRUE,
+                                     same_scale = FALSE)
+   css[["b"]][[2]][[1]]
+
+  },
+  expected = c("#F8696B", "#F48773", "#F0A67C", "#F3C285", "#F9DE8D",
+               "#EDE690", "#CFDC8C", "#B3D189", "#9CC986", "#86C183")
+  )
+ expect_equal(
+  {
+   # column a, decreasing FALSE
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, 10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = FALSE,
+                                     same_scale = FALSE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#86C183", "#9CC986", "#B3D189", "#CFDC8C", "#F8696B",
+               "#86C183", "#9CC986", "#B3D189", "#CFDC8C", "#F8696B")
+ )
+ expect_equal(
+  {
+   # column a, decreasing TRUE, negtive value
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, -10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = FALSE,
+                                     same_scale = FALSE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#F0A47C", "#F29076", "#F57C70", "#F8696B", "#86C183",
+               "#F0A47C", "#F29076", "#F57C70", "#F8696B", "#86C183")
+ )
+ expect_equal(
+  {
+   # column a, decreasing TRUE, negtive value, same_scale TRUE
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, -10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = FALSE,
+                                     same_scale = TRUE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#F9DF8E", "#F6D38A", "#F4C686", "#F1BA82", "#86C183",
+               "#F9DF8E", "#F6D38A", "#F4C686", "#F1BA82", "#86C183")
+ )
+ expect_equal(
+  {
+   # column b, decreasing TRUE, negtive value, same_scale TRUE
+   css <- make_css_colour_rank_theme(list(a =  rep(c(1:4, -10), 2),
+                                          b = 1:10),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = FALSE,
+                                     same_scale = TRUE)
+   css[["b"]][[2]][[1]]
+
+  },
+  expected = c("#F9DF8E", "#F6D38A", "#F4C686", "#F1BA82", "#EFAE7F",
+               "#F0A07B", "#F29277", "#F48473", "#F6766F", "#F8696B")
+ )
+ }
+)
 

--- a/tests/testthat/test_make_css_colour_rank_theme.R
+++ b/tests/testthat/test_make_css_colour_rank_theme.R
@@ -127,6 +127,28 @@ test_that("colour to value mapping is correct", {
   expected = c("#F9DF8E", "#F6D38A", "#F4C686", "#F1BA82", "#EFAE7F",
                "#F0A07B", "#F29277", "#F48473", "#F6766F", "#F8696B")
  )
+ expect_equal(
+  {
+   # factor columns
+   css <- make_css_colour_rank_theme(list(a =  factor(letters[1:4])),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = FALSE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#86C183", "#CFDC8C", "#F3C285", "#F8696B")
+ )
+ expect_equal(
+  {
+   # factor columns
+   css <- make_css_colour_rank_theme(list(a =  letters[1:4]),
+                                     c("#86c183", "#B9D48A", "#FCEC92", "#EFAE7F","#F8696B"),
+                                     decreasing = TRUE)
+   css[["a"]][[2]][[1]]
+
+  },
+  expected = c("#F8696B","#F3C285", "#CFDC8C", "#86C183")
+ )
  }
 )
 


### PR DESCRIPTION
In the previous version, the colour scaling for the vector `1:5` would be the same as for `c(1:4, 10)`. 

This follows a question on [stackoverflow](https://stackoverflow.com/questions/51818989/achieving-a-smooth-color-ramp/51820708#51820708)

Now the intevals between numbers is taken into account. If the intevals are equal, then the behaviour does not change. 