### PR TITLE
Issue 19

### DIFF
--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -44,7 +44,7 @@
 #' in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,
 #' the condition will be evaluated per column.
 #'
-#' @param levels. Deprecated. Please change the factor levels in the input data of \code{tableHTML}.
+#' @param levels Deprecated. Please change the factor levels in the input data of \code{tableHTML}.
 #'
 #' @inheritParams add_css_column
 #' @inheritParams base::order

--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -44,9 +44,6 @@
 #' in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,
 #' the condition will be evaluated per column.
 #'
-#' @param levels A character vector with the factor levels of the columns. Will be used to order factors for color ranks.
-#' If NULL, factor levels are in alphabetic order.
-#'
 #' @inheritParams add_css_column
 #' @inheritParams base::order
 #'
@@ -146,18 +143,22 @@ add_css_conditional_column <- function(tableHTML,
                                                              "White-Green", "White-Red", "White-Blue"),
                                        color_rank_css = NULL,
                                        decreasing = FALSE,
-                                       same_scale = TRUE,
-                                       levels = NULL) {
+                                       same_scale = TRUE) {
+
+  #persist attributes
+  attributes <- attributes(tableHTML)
 
   #checks
   if (!inherits(tableHTML, 'tableHTML')) stop('tableHTML needs to be a tableHTML object')
 
+  # check if data in attributes
+  if (is.null(attributes$data)) {
+   stop("tableHTML object does not have data in attributes. \nSee documentation in tableHTML()")
+  }
+
   if (!suppressWarnings(sum(is.na(as.numeric(columns)))) %in% c(0, length(columns))) {
     stop("columns must either be numeric or text, but not both")
   }
-
-  #persist attributes
-  attributes <- attributes(tableHTML)
 
   if (c("row_groups") %in% columns) {
     if (!attributes$row_groups) {
@@ -221,11 +222,14 @@ add_css_conditional_column <- function(tableHTML,
     if (is.null(color_rank_css)) {
       stop("color_rank_css needs to be provided for custom conditional formatting")
     }
-    if (! unique(unlist(lapply(1:length(color_rank_css), function(i) {
-      lengths(color_rank_css[[i]])
-    }))) == 1) {
-      stop('color_rank_css must be a list of corresponding css properties and css property values')
+    if (lengths(color_rank_css) != 2) {
+     stop("color_rank_css must be a list of 2 atomic vectors")
     }
+    # if (! unique(unlist(lapply(1:length(color_rank_css), function(i) {
+    #   lengths(color_rank_css[[i]])
+    # }))) == 1) {
+    #   stop('color_rank_css must be a list of corresponding css properties and css property values')
+    # }
     if (is.null(names(color_rank_css))) {
       stop('color_rank_css must be a named list')
     }
@@ -306,7 +310,7 @@ add_css_conditional_column <- function(tableHTML,
                                "between" = between,
                                value)
 
-    column_data <- extract_column_data(tableHTML, indices, levels)
+    column_data <- extract_column_data(tableHTML, indices)
 
     condition <- conditional_test_function(column_data = column_data,
                                            conditional = conditional,
@@ -315,7 +319,7 @@ add_css_conditional_column <- function(tableHTML,
   }
 
   if (!is.null(color_rank_theme_colors)) {
-    column_data <- extract_column_data(tableHTML, indices, levels)
+    column_data <- extract_column_data(tableHTML, indices)
     color_rank_css <- make_css_color_rank_theme(column_data,
                                        color_rank_theme_colors,
                                        decreasing = decreasing,

--- a/R/add_css_conditional_column.R
+++ b/R/add_css_conditional_column.R
@@ -44,6 +44,8 @@
 #' in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,
 #' the condition will be evaluated per column.
 #'
+#' @param levels. Deprecated. Please change the factor levels in the input data of \code{tableHTML}.
+#'
 #' @inheritParams add_css_column
 #' @inheritParams base::order
 #'
@@ -143,7 +145,8 @@ add_css_conditional_column <- function(tableHTML,
                                                              "White-Green", "White-Red", "White-Blue"),
                                        color_rank_css = NULL,
                                        decreasing = FALSE,
-                                       same_scale = TRUE) {
+                                       same_scale = TRUE,
+                                       levels = NULL) {
 
   #persist attributes
   attributes <- attributes(tableHTML)
@@ -155,6 +158,9 @@ add_css_conditional_column <- function(tableHTML,
   if (is.null(attributes$data)) {
    stop("tableHTML object does not have data in attributes. \nSee documentation in tableHTML()")
   }
+
+  # deprecated levels
+  if (! is.null(levels)) stop("levels is deprecated. Please change the input data directly")
 
   if (!suppressWarnings(sum(is.na(as.numeric(columns)))) %in% c(0, length(columns))) {
     stop("columns must either be numeric or text, but not both")

--- a/R/conditional_test_function.R
+++ b/R/conditional_test_function.R
@@ -5,9 +5,9 @@ conditional_test_function <- function(column_data,
                                       conditional,
                                       same_scale = TRUE,
                                       ...) {
-  
+
   arguments <- list(...)
-  
+
   col_names <- names(column_data)
   cols_context <- switch(ifelse(same_scale, "TRUE", "FALSE"),
                          "TRUE" = function(x) { return(unname(unlist(column_data))) },
@@ -15,7 +15,7 @@ conditional_test_function <- function(column_data,
   )
 
   lapply(column_data, function(cd) {
-    
+
     switch(conditional,
            "==" = cd == arguments$comparison_value,
            "!=" = cd != arguments$comparison_value,
@@ -26,11 +26,10 @@ conditional_test_function <- function(column_data,
            ">=" = cd >= arguments$comparison_value,
            "<" = cd < arguments$comparison_value,
            "<=" = cd <= arguments$comparison_value,
-           ">" = cd > arguments$comparison_value,
            contains = grepl(arguments$comparison_value, cd),
            min = cd == min(cols_context(cd)),
            max = cd == max(cols_context(cd))
            )
   })
-  
+
 }

--- a/R/extract_column_data.R
+++ b/R/extract_column_data.R
@@ -1,86 +1,31 @@
-extract_column_data <- function(tableHTML, indices, levels) {
-  
-  # checks
-  if (!inherits(tableHTML, 'tableHTML')) stop('tableHTML needs to be a tableHTML object')
-  
-  if (suppressWarnings(any(is.na(as.numeric(indices))))) stop('indices have to be numeric')
-  
-  col_classes <- attr(tableHTML, 'col_classes')
+extract_column_data <- function(tableHTML, indices) {
+
+ attributes <- attributes(tableHTML)
 
   data_cols <- list()
-  
+
   for (i in indices) {
-    
+
     if (identical(i, 0)) {
-      
-      split_cols <- strsplit(tableHTML, "</td>")
-      
-      data_col <- 
-        unlist(lapply(split_cols[[1]][1:length(split_cols[[1]])], function(x) {
-          
-          if (grepl('id="tableHTML_rownames"', x)) {
-            return(substr(x,
-                          max(unlist(gregexpr(">", x))) + 1,
-                          nchar(x)))
-          }
-          
-        }))
-      
-      data_cols <- append(data_cols, list(data_col))
+
+      data_cols <- append(data_cols, list(row.names(attributes$data)))
       names(data_cols)[length(data_cols)] <- "rownames"
-      
+
     } else if (identical(i, -1)) {
-      
-      split_cols <- strsplit(tableHTML, "</td>")
-      
-      data_col <- 
-        unlist(lapply(split_cols[[1]][1:length(split_cols[[1]])], function(x) {
-          
-          if (grepl('id="tableHTML_row_groups"', x)) {
-            return(substr(x,
-                          max(unlist(gregexpr(">", x))) + 1,
-                          nchar(x)))
-          }
-          
-        }))
-      
-      data_cols <- append(data_cols, list(data_col))
+
+      data_cols <- append(data_cols, attributes$row_groups_data[2])
       names(data_cols)[length(data_cols)] <- "row_groups"
-      
+
     } else {
-      
-      
-      split_cols <- strsplit(tableHTML, "</td>")
-      
-      data_col <- 
-        unlist(lapply(split_cols[[1]][1:length(split_cols[[1]])], function(x) {
-          
-          if (grepl(paste0('id="tableHTML_column_', i, '"'), x)) {
-            
-            return(substr(x, 
-                          max(unlist(gregexpr(">", x))) + 1,
-                          nchar(x)))
-            
-          }
-        }))
 
-      data_col <- convert_type(data_col, type = col_classes[i], levels = levels)
-      
-      data_cols <- append(data_cols, list(data_col))
+      data_cols <- append(data_cols, list(attributes$data[, i]))
       names(data_cols)[length(data_cols)] <- attr(tableHTML, "headers")[i]
-      
-      
-}
-    
-  }
-  
-  # data_cols <- lapply(data_cols, function(data_col) {
-  #   if (suppressWarnings(!any(is.na(as.numeric(data_col))))) {
-  #     as.numeric(data_col)
-  #   } else {
-  #     data_col
-  #   }
-  # })
-  return(data_cols)
+
+
 }
 
+  }
+
+  return(data_cols)
+
+}

--- a/R/tableHTML.R
+++ b/R/tableHTML.R
@@ -100,6 +100,10 @@
 #'   If you are working on Rgui (interactively) the table will be printed on your default browser.
 #'   If you set this to FALSE the HTML code will be printed on screen.
 #'
+#' @param add_data TRUE or FALSE. Defaults to TRUE. If set to true, the data.frame or matrix passed in
+#'  \code{obj} will be added to the attributes. If set to FALSE, the object will be smaller, but
+#'  \code{add_css_conditional_column} would not be applicable.
+#'
 #' @param theme Argument is Deprecated. Please use the add_theme function instead.
 #'
 #' @return A tableHTML object.
@@ -141,6 +145,7 @@ tableHTML <- function(obj,
                       escape = TRUE,
                       round = NULL,
                       replace_NA = NULL,
+                      add_data = TRUE,
                       theme = NULL) {
 
   #CHECKS----------------------------------------------------------------------------------------
@@ -201,6 +206,12 @@ tableHTML <- function(obj,
 
   #make sure collapse has the right argument
   collapse <- match.arg(collapse)
+
+  #check the add_data argument
+  ##TEST
+  if (!is.logical(add_data) | !length(add_data) == 1) {
+   stop("add_data must be either TRUE or FALSE")
+  }
 
   #make sure the first character of spacing is a number
   if (collapse %in% c('separate', 'separate_shiny')) {
@@ -439,6 +450,7 @@ tableHTML <- function(obj,
   attr(htmltable, 'second_headers') <- !is.null(second_headers)
   attr(htmltable, 'second_headers_data') <- second_headers
   attr(htmltable, 'table_class') <- class
+  if (add_data) attr(htmltable, 'data') <- obj
 
   #Adding Collapse arg------------------------------------------------------------------------
 

--- a/R/tableHTML.R
+++ b/R/tableHTML.R
@@ -240,9 +240,18 @@ tableHTML <- function(obj,
   #escape character > and < in the data and headers because it will close or open tags
   if (escape) {
    obj[sapply(obj, is.fachar)] <- lapply(obj[sapply(obj, is.fachar)], function(x) {
-    x <- gsub('>', '&#62;', x)
-    x <- gsub('<', '&#60;', x)
-    x
+    if (is.factor(x)) {
+     temp_levels <- levels(x)
+     x <- gsub('>', '&#62;', x)
+     x <- gsub('<', '&#60;', x)
+     temp_levels <- gsub('>', '&#62;', temp_levels)
+     temp_levels <- gsub('<', '&#60;', temp_levels)
+     factor(x, levels = temp_levels)
+    } else {
+     x <- gsub('>', '&#62;', x)
+     x <- gsub('<', '&#60;', x)
+     x
+    }
    })
    headers <- gsub('>', '&#62;', force(headers))
    headers <- gsub('<', '&#60;', force(headers))
@@ -268,9 +277,16 @@ tableHTML <- function(obj,
    })
   }
 
-  #replacing NA values for character columns
+  #replacing NA values for character and factor columns
   if (!is.null(replace_NA)) {
    obj[sapply(obj, is.fachar)] <- lapply(obj[sapply(obj, is.fachar)], function(x) {
+    if(is.factor(x)) {
+     levels(x) <- c(levels(x), replace_NA)
+     temp_levels <- levels(x)
+     x[is.na(x)] <- replace_NA
+     temp_levels[is.na(temp_levels)] <- replace_NA
+     factor(x, levels = temp_levels)
+    }
     x[is.na(x)] <- replace_NA
     x
    })

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,18 +34,6 @@ replace_style<- function(tableHTML, split, style, condition = NULL){
 
 }
 
-convert_type <- function(v, type, levels) {
-  switch(type,
-         numeric = as.numeric(v),
-         integer = as.integer(v),
-         factor = if (is.null(levels)) {
-           as.factor(v)
-         } else {
-           factor(v, levels = levels)
-         },
-         character = as.character(v))
-}
-
 fix_header_dupes <- function(h) {
  dup_positions <- which(duplicated(h))
  empty_strings <- sapply(dup_positions, function(x) paste0(rep(' ', x), collapse = ''))

--- a/man/add_css_conditional_column.Rd
+++ b/man/add_css_conditional_column.Rd
@@ -61,7 +61,7 @@ length as the number of rows for each style definition. You can use \code{make_c
 in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,
 the condition will be evaluated per column.}
 
-\item{levels.}{Deprecated. Please change the factor levels in the input data of \code{tableHTML}.}
+\item{levels}{Deprecated. Please change the factor levels in the input data of \code{tableHTML}.}
 }
 \value{
 A tableHTML object.

--- a/man/add_css_conditional_column.Rd
+++ b/man/add_css_conditional_column.Rd
@@ -61,8 +61,7 @@ length as the number of rows for each style definition. You can use \code{make_c
 in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,
 the condition will be evaluated per column.}
 
-\item{levels}{A character vector with the factor levels of the columns. Will be used to order factors for color ranks.
-If NULL, factor levels are in alphabetic order.}
+\item{levels.}{Deprecated. Please change the factor levels in the input data of \code{tableHTML}.}
 }
 \value{
 A tableHTML object.

--- a/man/tableHTML.Rd
+++ b/man/tableHTML.Rd
@@ -10,7 +10,7 @@ tableHTML(obj, rownames = TRUE, class = paste0("table_",
   second_headers = NULL, row_groups = NULL, caption = NULL,
   footer = NULL, border = 1, collapse = c("collapse", "separate",
   "separate_shiny"), spacing = "2px", escape = TRUE, round = NULL,
-  replace_NA = NULL, theme = NULL)
+  replace_NA = NULL, add_data = TRUE, theme = NULL)
 
 \method{print}{tableHTML}(x, viewer = TRUE, ...)
 }
@@ -64,6 +64,10 @@ numeric columns only. Defaults to NULL which means no rounding.}
 
 \item{replace_NA}{A sting that specifies with what to replace NAs in character
 or factor columns only. Defaults to NULL which means NAs will be printed.}
+
+\item{add_data}{TRUE or FALSE. Defaults to TRUE. If set to true, the data.frame or matrix passed in
+\code{obj} will be added to the attributes. If set to FALSE, the object will be smaller, but
+\code{add_css_conditional_column} would not be applicable.}
 
 \item{theme}{Argument is Deprecated. Please use the add_theme function instead.}
 

--- a/tests/testthat/test_add_css_conditional_column.R
+++ b/tests/testthat/test_add_css_conditional_column.R
@@ -85,8 +85,66 @@ test_that("Function fails for wrong inputs", {
                                               css = list('background-color', 'lightgray')),
                  'n not provided')
 
+  # n greater than number of rows
+  expect_error(tableHTML(mtcars) %>%
+                  add_css_conditional_column(conditional = "top_n",
+                                             columns = c(1),
+                                             css = list('background-color', 'lightgray'),
+                                             n = 33),
+                 "n cannot exceed")
 
+  # n equal to number of rows
+  expect_warning(tableHTML(mtcars) %>%
+                  add_css_conditional_column(conditional = "top_n",
+                                             columns = c(1),
+                                             css = list('background-color', 'lightgray'),
+                                             n = 32),
+                 "all rows selected")
 
+  # comparison value not provided
+  expect_error(tableHTML(mtcars) %>%
+                add_css_conditional_column(conditional = "==",
+                                           columns = c(1),
+                                           css = list('background-color', 'lightgray')),
+               "comparison value needed")
+
+  # begin values not numeric
+  expect_error(tableHTML(mtcars) %>%
+                add_css_conditional_column(conditional = "between",
+                                           columns = c(1),
+                                           css = list('background-color', 'lightgray'),
+                                           between = c("a", 1)),
+               "begin and end values of begin")
+
+  # custom colour rank theme selected with default colour rank theme
+  expect_error(tableHTML(mtcars) %>%
+                add_css_conditional_column(conditional = "color_rank",
+                                           columns = c(1),
+                                           color_rank_theme = "Custom"),
+               "color_rank_css needs to be provided")
+
+  # wrong format of custom css
+  expect_error(tableHTML(mtcars) %>%
+                add_css_conditional_column(conditional = "color_rank",
+                                           columns = c(1),
+                                           color_rank_theme = "Custom",
+                                           color_rank_css = list(mpg = list(list(rep("red", 32))))),
+               "color_rank_css must be a list of 2")
+
+  # unnamed list
+  expect_error(tableHTML(mtcars) %>%
+                add_css_conditional_column(conditional = "color_rank",
+                                           columns = c(1),
+                                           color_rank_theme = "Custom",
+                                           color_rank_css = list(list("background-color", list(rep("red", 32))))),
+               "color_rank_css must be a named list")
+
+})
+
+test_that("data is added", {
+ expect_error(tableHTML(mtcars, add_data = FALSE) %>%
+               add_css_conditional_column(),
+              "tableHTML object does not have data in attributes.")
 })
 
 test_that("equations and inequations work", {

--- a/tests/testthat/test_add_css_conditional_column.R
+++ b/tests/testthat/test_add_css_conditional_column.R
@@ -6,6 +6,11 @@ test_that("Function fails for wrong inputs", {
   expect_error(add_css_conditional_column(mtcars, 1),
                'tableHTML needs to be')
 
+ #deprecated levels
+ expect_error(tableHTML(mtcars) %>%
+               add_css_conditional_column(columns = 1, levels = "13"),
+              "levels is deprecated")
+
   # no columns specified
   expect_error(tableHTML(mtcars) %>% add_css_conditional_column(conditional = "==", value = 1,
                                                                 css = list('background-color', 'lightgray')),

--- a/tests/testthat/test_arguments_tableHTML.R
+++ b/tests/testthat/test_arguments_tableHTML.R
@@ -138,3 +138,23 @@ test_that("theme is deprecated", {
 
 })
 
+test_that("add_data works", {
+ expect_error(mtcars %>%
+               tableHTML(add_data = c(TRUE, FALSE)),
+              "add_data")
+ expect_error(mtcars %>%
+               tableHTML(add_data = "TRUE"),
+              "add_data")
+
+ with_data <- mtcars %>%
+  tableHTML(add_data = TRUE)
+
+ expect_identical(mtcars, attributes(with_data)[["data"]])
+
+ without_data <- mtcars %>%
+  tableHTML(add_data = FALSE)
+
+ expect_null(attributes(without_data)[["data"]])
+
+})
+

--- a/tests/testthat/test_extract_column_data.R
+++ b/tests/testthat/test_extract_column_data.R
@@ -1,33 +1,33 @@
 context("extract_column_data testing")
 
-test_that("Function fails for wrong inputs", {
-  #no tableHTML
-  expect_error(extract_column_data(mtcars, 1),
-               'tableHTML needs to be')
-  
-  # input not numeric
-  expect_error(tableHTML(mtcars) %>% 
-                 extract_column_data("character"),
-               'indices have to be numeric')
-  
-  #all checks ok
-  expect_error(tableHTML(mtcars) %>% 
-                 extract_column_data(indices = 1), NA)
-
-})
+# test_that("Function fails for wrong inputs", {
+#   #no tableHTML
+#   expect_error(extract_column_data(mtcars, 1),
+#                'tableHTML needs to be')
+#
+#   # input not numeric
+#   expect_error(tableHTML(mtcars) %>%
+#                  extract_column_data("character"),
+#                'indices have to be numeric')
+#
+#   #all checks ok
+#   expect_error(tableHTML(mtcars) %>%
+#                  extract_column_data(indices = 1), NA)
+#
+# })
 
 test_that("Correct values are extracted", {
-  
+
   #check correct values extracted
   for (n in names(mtcars)) {
-    expect_equal(unname(unlist(tableHTML(mtcars) %>% 
+    expect_equal(unname(unlist(tableHTML(mtcars) %>%
                    extract_column_data(indices = which(names(mtcars) == n)))),
                  mtcars[, n])
   }
   #check rownames extraction
-  expect_equal(unname(unlist(tableHTML(mtcars) %>% 
+  expect_equal(unname(unlist(tableHTML(mtcars) %>%
                  extract_column_data(indices = 0))),
                rownames(mtcars))
-  
+
 })
 

--- a/tests/testthat/test_odd_even.R
+++ b/tests/testthat/test_odd_even.R
@@ -23,3 +23,13 @@ test_that("even outputs correct", {
  expect_equal(even(1:10), c(2, 4, 6, 8, 10))
 
 })
+
+test_that("checks work", {
+
+ expect_error(even(TRUE),
+              "vec needs to be numeric")
+
+ expect_error(odd("a"),
+              "vec needs to be numeric")
+
+})

--- a/vignettes/conditional_column.Rmd
+++ b/vignettes/conditional_column.Rmd
@@ -255,22 +255,26 @@ tableHTML(mtcars,
                              columns = "rownames")
 ```
 
-### Sorting factors with levels
+### Update to sorting factors with levels
 
-For factors, the default order of levels is alphabetic. If you want to change
-it to a specific order, you can add them with the argument `levels`.
+In the old version 1.1.0 of tableHTML, the default order of factor levels was alphabetic,
+because the data was parsed from the HTML. Since version 2.0.0, 
+the data comes from the tableHTML objects attributes, so the factors and levels are preserved.
+The `levels` argument is therfore deprecated.
 
 ```{r example_20}
 df <- data.frame(factor_alphabetic = c('d', 'a', 'e', 'a', 'd', 'd', 'a', 'c', 'd', 'a'),
                  factor_ordered = c('D', 'A', 'E', 'A', 'D', 'D', 'A', 'C', 'D', 'A'),
                  stringsAsFactors = TRUE)
+
+df$factor_ordered <- factor(df, levels = c('B', 'D', 'A', 'E', 'C'))
+
 tableHTML(df, 
           rownames = FALSE) %>%
   add_css_conditional_column(color_rank_theme = 'White-Green',
                              columns = 1) %>%
   add_css_conditional_column(color_rank_theme = 'White-Green', 
-                             columns = 2,
-                             levels = c('B', 'D', 'A', 'E', 'C'))
+                             columns = 2)
 ```
 
 ### Color rank 


### PR DESCRIPTION
This PR closes issue #19 .

In addition:

- `add_css_conditional_column`  now uses the data in the data attribute
- factors are now preserved when `escape = TRUE` and `replace_NA != NULL`
- levels in `add_css_conditional_column` is deprecated
- new tests for various functions implemented