### PR TITLE
Don't statically link to shiny's uiOutput/renderUI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: A tool to create and style HTML tables with CSS. These can
     (which also work with shiny).
 License: MIT + file LICENSE
 LazyData: TRUE
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.2
 Suggests:
     testthat,
     knitr,

--- a/R/render_tableHTML_family.R
+++ b/R/render_tableHTML_family.R
@@ -4,14 +4,12 @@
 #' ui.R file. Internally, it just calls uiOutput, since tableHTML creates HTML code.
 #'
 #' @param outputId input name.
-#' @param inline use an inline (span()) or block container (div()) for the output.
-#' @param container  a function to generate an HTML element to contain the text. 
-#' @param ... Other arguments to pass to the container tag function. This is useful for providing 
-#'        additional classes for the tag.
-#' 
-#' @seealso \code{uiOutput} 
-#' 
-#' @examples 
+#' @param ... Other arguments to passed along to [shiny::uiOutput()]
+#'
+#' @seealso [uiOutput()]
+#' @md
+#'
+#' @examples
 #' \dontrun{
 #' 
 #' library(shiny)
@@ -32,22 +30,22 @@
 #' }
 #' 
 #' @export
-tableHTML_output <- shiny::uiOutput
+tableHTML_output <- function(outputId, ...) {
+  shiny::uiOutput(outputId, ...)
+}
 
 #' Implementing tableHTML in shiny
 #' 
 #' This function is used to implement tableHTML in a shiny app. This function is used in the shiny
 #' server.R file. Internally, it just calls renderUI, since tableHTML creates HTML code.
-#' 
-#' @param expr A tableHTML object. 
-#' @param env An environment.
-#' @param quoted  A boolean value. Whether the expression is quoted or not.
-#' @param outputArgs A list of arguments to be passed through to the implicit call to uiOutput when 
-#'        renderUI is used in an interactive R Markdown document.
-#' 
-#' @seealso \code{renderUI} 
-#' 
-#' @examples 
+#'
+#' @param expr A tableHTML object.
+#' @param ... Other arguments passed along to [shiny::renderUI()].
+#'
+#' @seealso [shiny::renderUI()]
+#' @md
+#'
+#' @examples
 #' \dontrun{
 #' 
 #' library(shiny)
@@ -68,6 +66,10 @@ tableHTML_output <- shiny::uiOutput
 #' }
 #' 
 #' @export
-render_tableHTML <- shiny::renderUI
+render_tableHTML <- function(expr, ...) {
+ shiny::renderUI(expr, ...)
+}
+
+
 globalVariables('func')
 

--- a/man/add_css_conditional_column.Rd
+++ b/man/add_css_conditional_column.Rd
@@ -7,8 +7,8 @@
 add_css_conditional_column(
   tableHTML,
   columns,
-  conditional = c("color_rank", "==", "!=", "min", "max", "top_n", "bottom_n", ">",
-    ">=", "<", "<=", "between", "contains", "logical"),
+  conditional = c("color_rank", "==", "!=", "min", "max", "top_n", "bottom_n", ">", ">=",
+    "<", "<=", "between", "contains", "logical"),
   n = NULL,
   value = NULL,
   between = NULL,
@@ -65,8 +65,9 @@ length as the number of rows for each style definition. You can use \code{make_c
 
 \item{decreasing}{logical.  Should the sort order be increasing or
     decreasing? For the \code{"radix"} method, this can be a vector of
-    length equal to the number of arguments in \code{\dots}. For the
-    other methods, it must be length one.}
+    length equal to the number of arguments in \code{\dots} and the
+    elements are recycled as necessary.
+    For the other methods, it must be length one.}
 
 \item{same_scale}{Logical. This flag indicates whether the condition should be applied to columns individually or
 in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,

--- a/man/make_css_color_rank_theme.Rd
+++ b/man/make_css_color_rank_theme.Rd
@@ -24,8 +24,9 @@ that should be used. Default is \code{'backgroud-color'}}
 
 \item{decreasing}{logical.  Should the sort order be increasing or
     decreasing? For the \code{"radix"} method, this can be a vector of
-    length equal to the number of arguments in \code{\dots}. For the
-    other methods, it must be length one.}
+    length equal to the number of arguments in \code{\dots} and the
+    elements are recycled as necessary.
+    For the other methods, it must be length one.}
 
 \item{same_scale}{Logical. This flag indicates whether the condition should be applied to columns individually or
 in conjunction. If TRUE, the condition will be evaluated on all values of all \code{columns}. If FALSE,

--- a/man/render_tableHTML.Rd
+++ b/man/render_tableHTML.Rd
@@ -4,22 +4,12 @@
 \alias{render_tableHTML}
 \title{Implementing tableHTML in shiny}
 \usage{
-render_tableHTML(
-  expr,
-  env = parent.frame(),
-  quoted = FALSE,
-  outputArgs = list()
-)
+render_tableHTML(expr, ...)
 }
 \arguments{
 \item{expr}{A tableHTML object.}
 
-\item{env}{An environment.}
-
-\item{quoted}{A boolean value. Whether the expression is quoted or not.}
-
-\item{outputArgs}{A list of arguments to be passed through to the implicit call to uiOutput when 
-renderUI is used in an interactive R Markdown document.}
+\item{...}{Other arguments passed along to \code{\link[shiny:renderUI]{shiny::renderUI()}}.}
 }
 \description{
 This function is used to implement tableHTML in a shiny app. This function is used in the shiny
@@ -47,5 +37,5 @@ server = function(input, output) {
 
 }
 \seealso{
-\code{renderUI}
+\code{\link[shiny:renderUI]{shiny::renderUI()}}
 }

--- a/man/tableHTML_output.Rd
+++ b/man/tableHTML_output.Rd
@@ -4,22 +4,12 @@
 \alias{tableHTML_output}
 \title{Implementing tableHTML in shiny}
 \usage{
-tableHTML_output(
-  outputId,
-  inline = FALSE,
-  container = if (inline) span else div,
-  ...
-)
+tableHTML_output(outputId, ...)
 }
 \arguments{
 \item{outputId}{input name.}
 
-\item{inline}{use an inline (span()) or block container (div()) for the output.}
-
-\item{container}{a function to generate an HTML element to contain the text.}
-
-\item{...}{Other arguments to pass to the container tag function. This is useful for providing 
-additional classes for the tag.}
+\item{...}{Other arguments to passed along to \code{\link[shiny:htmlOutput]{shiny::uiOutput()}}}
 }
 \description{
 This function is used to implement tableHTML in a shiny app. It is used in the shiny
@@ -47,5 +37,5 @@ server = function(input, output) {
 
 }
 \seealso{
-\code{uiOutput}
+\code{\link[=uiOutput]{uiOutput()}}
 }


### PR DESCRIPTION
shiny 1.7.4 (soon to be released) adds a `fill` parameter to `uiOutput()`, which causes this new WARNING in `R CMD check` of `{tableHTML}`

```
Codoc mismatches from documentation object 'tableHTML_output':
  tableHTML_output
Code: function(outputId, inline = FALSE, container = if (inline) span
  else div, fill = FALSE, ...)
  Docs: function(outputId, inline = FALSE, container = if (inline) span
    else div, ...)
    Argument names in code not in docs:
  fill
Mismatches in argument names:
  Position: 4 Code: fill Docs: ...
```


This PR fixes the issue (as well as the more serious issue of statically linking functions at install-time...which can cause all sorts of bad things can happen).

I plan on submitting shiny 1.7.4 within the next couple weeks. If you could please submit this patch fix to CRAN before then, it'd be much appreciated.